### PR TITLE
fix: #11 - Crash when extracting last item in vest row via radial menu

### DIFF
--- a/src/main/java/dev/satherov/utilityvest/client/screen/RadialMenuScreen.java
+++ b/src/main/java/dev/satherov/utilityvest/client/screen/RadialMenuScreen.java
@@ -226,6 +226,10 @@ public class RadialMenuScreen extends Screen {
         if (distance < RadialMenuScreen.CENTER_DEAD_ZONE || distance > RadialMenuScreen.OUTER_RADIUS + RadialMenuScreen.HOVER_EXTEND) {
             return -1;
         }
+
+        if (this.menuItems.isEmpty()) {
+            return -1;
+        }
         
         float angle = (float) Math.toDegrees(Math.atan2(dy, dx)) + 90;
         if (angle < 0) angle += 360;


### PR DESCRIPTION
Added check if menuItems is empty before using it for math.

Fixes #11 