### PR TITLE
feat: add config option to hide stack size label for single items/ tools

### DIFF
--- a/src/generated/resources/.cache/962c517d2504531daa1791f186a323fb445028ac
+++ b/src/generated/resources/.cache/962c517d2504531daa1791f186a323fb445028ac
@@ -1,5 +1,5 @@
-// 1.21.1	2026-02-28T11:21:07.250360813	Utility Vest Data Provider
-fcabe917d7e72f9ec80884e3b10c61c4edf546bc assets/utilityvest/lang/en_us.json
+// 1.21.1	2026-02-28T14:04:24.5508191	Utility Vest Data Provider
+1ee8426c7c1cca752e3f180db1bed21cefaef0c6 assets/utilityvest/lang/en_us.json
 def49994fc9441e21b5785fc0b0b80047b4451e8 assets/utilityvest/models/item/diamond_utility_vest.json
 94fbfb1496984d08cec6a2e9cdfd56d6d3c140dc assets/utilityvest/models/item/gold_utility_vest.json
 bb9c0c3956b00d0290a12ecc42c233f57e471c5f assets/utilityvest/models/item/iron_utility_vest.json

--- a/src/generated/resources/assets/utilityvest/lang/en_us.json
+++ b/src/generated/resources/assets/utilityvest/lang/en_us.json
@@ -32,5 +32,6 @@
   "tooltip.utilityvest.vest.radial": "Hold %s + a number key to open the quick-select menu",
   "tooltip.utilityvest.vest.restock": "Press %s to insert items matching your filters into the vest's inventory",
   "utilityvest.configuration.invert_radial_scroll": "Invert Radial Scroll",
+  "utilityvest.configuration.radial_stack_count": "Radial Stack Count",
   "utilityvest.configuration.radial_tooltip": "Radial Tooltip"
 }

--- a/src/main/java/dev/satherov/utilityvest/client/screen/RadialMenuScreen.java
+++ b/src/main/java/dev/satherov/utilityvest/client/screen/RadialMenuScreen.java
@@ -6,6 +6,8 @@ import dev.satherov.utilityvest.config.UVConfig;
 import dev.satherov.utilityvest.core.lang.UVLanguage;
 import dev.satherov.utilityvest.network.UVNetworking;
 
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.ArmorItem;
 import net.neoforged.neoforge.capabilities.Capabilities;
 
 import net.minecraft.ChatFormatting;
@@ -168,7 +170,20 @@ public class RadialMenuScreen extends Screen {
         
         if (!stack.isEmpty()) {
             graphics.renderItem(stack, x, y);
+
+            UVConfig.RadialStackCountDisplay display = UVConfig.RadialStackCount;
+
+            if (display.equals(UVConfig.RadialStackCountDisplay.NEVER) && stack.getCount() == 1) {
+                return;
+            }
+
+            if (display.equals(UVConfig.RadialStackCountDisplay.TOOLS_ONLY)
+            && (stack.has(DataComponents.TOOL) || stack.getItem() instanceof ArmorItem)) {
+                return;
+            }
+
             graphics.renderItemDecorations(this.font, stack, x, y, String.valueOf(stack.getCount()));
+
         }
         
         if (!isHovered) return;

--- a/src/main/java/dev/satherov/utilityvest/config/UVConfig.java
+++ b/src/main/java/dev/satherov/utilityvest/config/UVConfig.java
@@ -32,4 +32,25 @@ public class UVConfig {
             return this.comment;
         }
     }
+
+    @ConfigVal(name = "radial_stack_count", comment = "Defines when stack size label should be displayed for single items")
+    @ConfigVal.Enum(RadialStackCountDisplay.class)
+    public static RadialStackCountDisplay RadialStackCount = RadialStackCountDisplay.TOOLS_ONLY;
+
+    public enum RadialStackCountDisplay implements ConfigEnum {
+        ALWAYS("Always show the stack counts for single items"),
+        TOOLS_ONLY("Hide stack counts for tools & armor only"),
+        NEVER("Never show the stack count for single items"),;
+
+        RadialStackCountDisplay(String comment) {
+            this.comment = comment;
+        }
+
+        public final String comment;
+
+        @Override
+        public String comment() {
+            return this.comment;
+        }
+    }
 }

--- a/src/main/java/dev/satherov/utilityvest/core/lang/UVLanguage.java
+++ b/src/main/java/dev/satherov/utilityvest/core/lang/UVLanguage.java
@@ -43,6 +43,7 @@ public enum UVLanguage implements ILangEntry {
     
     CONFIG_INVERT_RADIAL_SCROLL("utilityvest.configuration.invert_radial_scroll", "Invert Radial Scroll"),
     CONFIG_RADIAL_TOOLTIP("utilityvest.configuration.radial_tooltip", "Radial Tooltip"),
+    CONFIG_RADIAL_STACK_COUNT("utilityvest.configuration.radial_stack_count", "Radial Stack Count"),
     ;
     
     private final String key;


### PR DESCRIPTION
- defaults to TOOLS_ONLY
- current implementation equivalent to ALWAYS

Video examples below:

## `ALWAYS:`

https://github.com/user-attachments/assets/169db0ee-ff34-4607-b905-aa949df71d89


## `TOOLS_ONLY:`

https://github.com/user-attachments/assets/25bb8fa0-5066-4174-951c-bdd6f8ab5567


## `NEVER:`

https://github.com/user-attachments/assets/cff83442-1caf-4d84-9cae-298a4d92788c
